### PR TITLE
Styling changes to breakdowns.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -29,14 +29,22 @@ ul{
     background-color:rgba(255, 255, 255, 0.86); 
     color: #00BCD4;
 }
-.breakdows-information {
+.breakdowns-list-container {
+    overflow: hidden; 
+    height: 80%;
+}
+.breakdowns-list {
+    overflow-y: scroll; 
+    height: 100%;
+}
+.breakdowns-information {
     white-space: none;
     overflow-y:scroll;
     min-height: 155px;
     margin-top: -4%;
     background-color: #808080;
 }
-.breakdows-information hr{
+.breakdowns-information hr{
     margin-top: 0;
     margin-bottom: 1%;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -32,7 +32,7 @@ ul{
 .breakdows-information {
     white-space: none;
     overflow-y:scroll;
-    height: 155px;
+    min-height: 155px;
     margin-top: -4%;
     background-color: #808080;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -73,15 +73,15 @@
                 <img id="imagen" src="img/aee.png" alt=""> 
                 </br>
             {{/link-to}}
-            <div class="medium-12 columns" style="overflow: hidden; height: 80%;">
-                <ul class="side-nav side-color" style="overflow-y: scroll; height: 100%;">
+            <div class="medium-12 columns breakdowns-list-container">
+                <ul class="side-nav side-color breakdowns-list">
                     {{#link-to 'breakdowns.report' class="button expand home-button"}}
                         Report Breakdown
                     {{/link-to}}
 
                     {{#each data in controller}}
-                    <li class="breakdown-list">
-                        <a {{action 'highlightMap' data.Pueblo}} class="breakdown-list">
+                    <li class="breakdowns-list-item">
+                        <a {{action 'highlightMap' data.Pueblo}} class="breakdowns-list-item-link">
                             {{data.Pueblo}}
                             <span class="white label right">
                                 {{[data.Cantidad de averias]}}
@@ -134,7 +134,7 @@
 
     <script type="text/x-handlebars" id="breakdowns/view/specific">
         {{outlet}}
-        <div id="information" class="medium-12 columns breakdows-information">
+        <div id="information" class="medium-12 columns breakdowns-information">
             {{#each data in controller}}
             <h1 style="color: #fff;">{{data.Pueblo}}</h1>
             <hr/>


### PR DESCRIPTION
Changed height to min-height in .breakdown-information found in style.css. This will make the breakdowns container grow and shrink better.
Added breakdowns-list-container and breakdowns-list to style.css.
Added breakdowns-list-item and breakdowns-list-item-link to breakdowns side-nav list item and links.
Removed inline styling and moved them to style.css breakdowns-list-container and breakdowns-list classes.
